### PR TITLE
Integrate connect-sqlite3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+
+# Change this for production use!
+#
+# Reccommended is one of the CodeIgniter Encryption Keys on
+# http://randomkeygen.com
+SESSION_SECRET=superSecretSessionKey

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@ PORT=3000
 
 # Change this for production use!
 #
-# Reccommended is one of the CodeIgniter Encryption Keys on
+# Recommended is one of the CodeIgniter Encryption Keys on
 # http://randomkeygen.com
 SESSION_SECRET=superSecretSessionKey

--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,15 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# DotEnv configuration
+.env
+
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
+
+# Session store db
+sessions.db
 
 # Debug log from npm
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 ## Developing
 
 After cloning the repo run `npm install` to install the app's dependencies.
-Then, to run the app use `npm run debug`.
+
+If it doesn't already exist in your environment, create a new `.env` file in
+the project root directory, copying `.env.example` and modifying as necessary
+for the environment. (**Change the `SESSION_SECRET`!**)
+
+Then, to run and debug the app use `npm run debug`.
 
 ## Copyright and license
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@ var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');
 var logger = require('morgan');
-var cookieParser = require('cookie-parser');
+var session = require('express-session');
+var SQLiteStore = require('connect-sqlite3')(session);
 var bodyParser = require('body-parser');
 
 var routes = require('./routes/index');
@@ -18,7 +19,13 @@ app.set('view engine', 'ejs');
 app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(cookieParser());
+app.use(session({
+  store: new SQLiteStore,
+  secret: process.env.SESSION_SECRET || 'reallyBadSecret',
+  cookie: { maxAge: 24 * 60 * 60 * 1000 }, // 1 day
+  resave: false,
+  saveUninitialized: false
+}));
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', routes);

--- a/bin/www
+++ b/bin/www
@@ -9,6 +9,11 @@ var debug = require('debug')('Jama-Software:server');
 var http = require('http');
 
 /**
+ * Load .env environment variable configuration.
+ */
+require('dotenv').config();
+
+/**
  * Get port from environment and store in Express.
  */
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   },
   "dependencies": {
     "body-parser": "~1.13.2",
-    "cookie-parser": "~1.3.5",
+    "connect-sqlite3": "^0.9.8",
     "debug": "~2.2.0",
+    "dotenv": "^2.0.0",
     "ejs": "~2.3.3",
     "express": "~4.13.1",
+    "express-session": "^1.13.0",
     "morgan": "~1.6.1",
     "serve-favicon": "~2.3.0"
   }


### PR DESCRIPTION
Fully integrated [connect-sqlite3](https://www.npmjs.com/package/connect-sqlite3).

Added the `dotenv` package for environment configuration and to store the session secret key as well as instructions for developing with a `.env` file.

I removed `cookie-parser` dependency, per [this note](https://github.com/expressjs/session/blob/1940ce9abc00e123967c2b11c4426da48c3681c9/README.md#sessionoptions).

I tested using `npm run debug` and all seems well.