### PR TITLE
Cache node_modules between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ language: node_js
 node_js:
   - "6"
   - "6.1"
+
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
This should shave off about 40 seconds from the travis build time, letting us see build results even faster.